### PR TITLE
Filtering PI

### DIFF
--- a/caliopen/api/user/contact.py
+++ b/caliopen/api/user/contact.py
@@ -7,7 +7,7 @@ import json
 import colander
 from cornice.resource import resource, view
 from pyramid.response import Response
-from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.httpexceptions import HTTPBadRequest, HTTPExpectationFailed
 
 from caliopen.base.user.core import (Contact as CoreContact,
                                      PublicKey as CorePublicKey)
@@ -62,7 +62,7 @@ class Contact(Api):
         except NotFound:
             raise ResourceNotFound('No such contact')
         if pi_range[0] > contact.privacy_index < pi_range[1]:
-            raise HTTPBadRequest('Invalid privacy index')
+            raise HTTPExpectationFailed('Invalid privacy index')
         return {'contacts': ReturnContact.build(contact).serialize()}
 
     @view(renderer='json', permission='authenticated')

--- a/caliopen/api/user/contact.py
+++ b/caliopen/api/user/contact.py
@@ -55,11 +55,14 @@ class Contact(Api):
 
     @view(renderer='json', permission='authenticated')
     def get(self):
+        pi_range = self.request.authenticated_userid.pi_range
         contact_id = self.request.matchdict.get('contact_id')
         try:
             contact = CoreContact.get(self.user, contact_id)
         except NotFound:
             raise ResourceNotFound('No such contact')
+        if pi_range[0] > contact.privacy_index < pi_range[1]:
+            raise HTTPBadRequest('Invalid privacy index')
         return {'contacts': ReturnContact.build(contact).serialize()}
 
     @view(renderer='json', permission='authenticated')

--- a/caliopen/api/user/contact.py
+++ b/caliopen/api/user/contact.py
@@ -42,11 +42,15 @@ class Contact(Api):
 
     @view(renderer='json', permission='authenticated')
     def collection_get(self):
-        results = CoreContact.find(self.user, None,
-                                   limit=self.get_limit(),
-                                   offset=self.get_offset())
-        data = [ReturnContact.build(x).serialize()
-                for x in results]
+        pi_range = self.request.authenticated_userid.pi_range
+        filter_params = {'min_pi': pi_range[0],
+                         'max_pi': pi_range[1],
+                         'limit': self.get_limit(),
+                         'offset': self.get_offset()}
+        log.debug('Filter parameters {}'.format(filter_params))
+        results = CoreContact._model_class.search(self.user, **filter_params)
+        data = [ReturnContact.build(CoreContact.get(self.user, x.meta.id)).
+                serialize() for x in results]
         return {'contacts': data, 'total': len(data)}
 
     @view(renderer='json', permission='authenticated')

--- a/caliopen/api/user/contact.py
+++ b/caliopen/api/user/contact.py
@@ -49,7 +49,7 @@ class Contact(Api):
                          'offset': self.get_offset()}
         log.debug('Filter parameters {}'.format(filter_params))
         results = CoreContact._model_class.search(self.user, **filter_params)
-        data = [ReturnContact.build(CoreContact.get(self.user, x.meta.id)).
+        data = [ReturnContact.build(CoreContact.get(self.user, x.contact_id)).
                 serialize() for x in results]
         return {'contacts': data, 'total': len(data)}
 


### PR DESCRIPTION
filter on API using PI range header for contact.

One ede case is not covered: when PI range is outside of contact related to logged user, nothing is checked. We must define comportment in such situation